### PR TITLE
Simpler JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Feature
 
 * `JSONSerialization` extension.
+* The `Koting` protocol is split into `Dekoting` and `Enkoting`.
 
 ## 0.2.2
 

--- a/Dekoter/Classes/JSONSerialization+Dekoter.swift
+++ b/Dekoter/Classes/JSONSerialization+Dekoter.swift
@@ -25,6 +25,7 @@
 
 import Foundation
 
+/// An `JSONSerialization` extension to deserialize objects which implement the `Koting` protocol from JSON.
 extension JSONSerialization {
     
     /// Creates an object which implements the `Koting` protocol from JSON data.
@@ -33,7 +34,7 @@ extension JSONSerialization {
     ///   - data: JSON data.
     ///   - opt: Options.
     /// - Returns: A deserialized object.
-    class func de_jsonObject<T: Koting>(with data: Data, options opt: JSONSerialization.ReadingOptions = []) -> T? {
+    class func de_jsonObject<T: Dekoting>(with data: Data, options opt: JSONSerialization.ReadingOptions = []) -> T? {
         guard let object = try? jsonObject(with: data, options: opt),
             let dict = object as? [AnyHashable: Any] else {
             
@@ -48,7 +49,7 @@ extension JSONSerialization {
     ///   - data: JSON data.
     ///   - opt: Options.
     /// - Returns: A deserialized array.
-    class func de_jsonObject<T: Koting>(with data: Data, options opt: JSONSerialization.ReadingOptions = []) -> [T]? {
+    class func de_jsonObject<T: Dekoting>(with data: Data, options opt: JSONSerialization.ReadingOptions = []) -> [T]? {
         guard let object = try? jsonObject(with: data, options: opt),
             let dicts = object as? [[AnyHashable: Any]] else {
             
@@ -62,7 +63,7 @@ extension JSONSerialization {
 
 fileprivate extension JSONSerialization {
     
-    class func de_serializedObject<T: Koting>(from dict: [AnyHashable: Any]) -> T? {
+    class func de_serializedObject<T: Dekoting>(from dict: [AnyHashable: Any]) -> T? {
         let coder = JSONKoter(objects: dict)
         guard let object = T(koter: coder) else {
             return nil

--- a/Dekoter/Classes/Koting.swift
+++ b/Dekoter/Classes/Koting.swift
@@ -26,17 +26,26 @@
 import Foundation
 
 /// Structs and classes which implement this protocol may be used in conjunction with
-/// extension from the `Dekoter` library.
+/// extensions from the `Dekoter` library.
 ///
-/// - To save objects to UserDefaults.
+/// - To save objects to `UserDefaults`.
+/// - To deserialize objects from JSON.
 /// - To convert objects to `Data` (archive) and back (unarchive).
-public protocol Koting {
+public protocol Koting: Dekoting, Enkoting {
+}
+
+/// Is used for decoding (or deserialization).
+public protocol Dekoting {
     
     /// Initializes an object based on a given coder.
     /// Needs to be implemented. Don't call this method directly.
     ///
     /// - Parameter koter: The coder containing the data to be taken to initialize the object.
     init?(koter: Koter)
+}
+
+/// Is used for encoding (or serialization).
+public protocol Enkoting {
     
     /// Populates a coder with all the data to be encoded.
     /// Needs to be implemented. Don't call this method directly.

--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ let oneCat: Cat? = JSONSerialization.de_jsonObject(with: oneCatData)
 let cats: [Cat]? = JSONSerialization.de_jsonObject(with: catsData)
 ```
 
+For structs which make use only of this feature there's no need to implement the `Koting` protocol (contains 2 methods), instead implement a `Dekoting` protocol (only 1 method).
+
 ## Micromission
 
 The library is small but proud of its mission, though the latter is also not that big. It's willing to serve developers as good as `NSCoding` does. Developers shouldn't feel lost and disappointed without a convenient tool to convert their Swift structs to `Data` and back.


### PR DESCRIPTION
* The `Koting` protocol is split into `Dekoting` and `Enkoting`.
* A `JSONSerialization` extension requires only `Dekoting`.