### PR TITLE
Removed the redundant use of NSData

### DIFF
--- a/Dekoter.podspec
+++ b/Dekoter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Dekoter'
-  s.version          = '0.3.0'
+  s.version          = '0.3.1'
   s.summary          = "NSCoding's counterpart for Swift structs."
   
   s.description      = <<-DESC

--- a/Dekoter/Classes/NSKeyedUnarchiver+Dekoter.swift
+++ b/Dekoter/Classes/NSKeyedUnarchiver+Dekoter.swift
@@ -33,7 +33,7 @@ public extension NSKeyedUnarchiver {
     /// - Parameter data: The archived object.
     /// - Returns: The object similar to the one that was previously archived.
     public class func de_unarchiveObject<T: Koting>(with data: Data) -> T? {
-        guard let topObject = try? unarchiveTopLevelObjectWithData(data as NSData),
+        guard let topObject = try? unarchiveTopLevelObjectWithData(data),
             let objects = topObject as? [AnyHashable: Any] else {
                 
             return nil


### PR DESCRIPTION
The use of NSData is causing a compile-time error in Swift. Removing that doesn't seem to affect the overall functionality.

Also bumped the version in the Podspec to reflect the update in CocoaPods. 